### PR TITLE
Update packaging container for new codenames

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,6 +1,9 @@
 ARG DEBIAN_RELEASE=stretch
 FROM ev3dev/ev3dev-$DEBIAN_RELEASE-ev3-base
 
+ARG DEBIAN_RELEASE
+ENV DISTRO=$DEBIAN_RELEASE
+
 # copy QEMU
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -41,8 +41,11 @@ PKG="jri-${DEB_JRI_MAJOR}-${DEB_JRI_PLATFORM}"
 PKGVER="${DEB_JRI_MAJOR}.${DEB_JRI_MINOR}.${DEB_JRI_PATCH}~${DEB_JRI_BUILD}"
 PKGNAME="${PKG}_${PKGVER}"
 DATE=$(LC_ALL=C date -R)
-if [ ! -z "$DISTRO" ]; then
-    DISTRO=stable
+if [ -z "$DISTRO" ]; then
+    echo "Please choose a target distro." >&2
+    exit 1
+else
+    echo "Building for ev3dev-$DISTRO"
 fi
 
 PKGDIR="/build/pkg/$PKGNAME"


### PR DESCRIPTION
This tunnels the `stretch`/`buster` codename into the existing `DISTRO` environment variable, which used to contain `stable`/`testing` (manually via docker commandline).

Affects #37 (this does not test the upload itself).
Can be merged independently #39.
Not yet tested.