### PR TITLE
Do not include JMODs in the JDK archive

### DIFF
--- a/scripts/zip.sh
+++ b/scripts/zip.sh
@@ -37,6 +37,9 @@ cp "$BUILDDIR/metadata" "jri/metadata";   echo "TYPE=\"jri\""   >>"jri/metadata"
 cp "$BUILDDIR/metadata" "jdk/metadata";   echo "TYPE=\"jdk\""   >>"jdk/metadata"
 cp "$BUILDDIR/metadata" "jmods/metadata"; echo "TYPE=\"jmods\"" >>"jmods/metadata"
 
+# remove jmods from jdk
+rm -rf jdk/jmods
+
 # create zip files
 echo "[ZIP] Creating JRI archive"
 tar -cf - jri   | pigz -9 > "$BUILDDIR/jri-$JDKPLATFORM.tar.gz"


### PR DESCRIPTION
This PR adds a deletion of the jmods folder before the JDK archive is created.

Fixes https://github.com/ev3dev-lang-java/openjdk-ev3/issues/43