### PR TITLE
Try to fix build failure on JDK Master

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -135,6 +135,12 @@ if [ ! -d "$JDKDIR" ]; then
     PATCHES="$PATCHES cds"
   fi
 
+  # generic broken build
+  if [ -f "$SCRIPTDIR/${PATCHVER}_klassinline.patch" ]; then
+    patch -p1 -i "$SCRIPTDIR/${PATCHVER}_klassinline.patch"
+    PATCHES="$PATCHES klassinline"
+  fi
+
   # write patches to metadata
   echo "[FETCH] Patches applied: $PATCHES"
   echo "JAVA_PATCHES=\"$PATCHES\"" >>"$BUILDDIR/metadata"

--- a/scripts/jdk14_klassinline.patch
+++ b/scripts/jdk14_klassinline.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hotspot/cpu/arm/vtableStubs_arm.cpp b/src/hotspot/cpu/arm/vtableStubs_arm.cpp
+index 2c564b818..f84e11662 100644
+--- a/src/hotspot/cpu/arm/vtableStubs_arm.cpp
++++ b/src/hotspot/cpu/arm/vtableStubs_arm.cpp
+@@ -32,6 +32,7 @@
+ #include "oops/compiledICHolder.hpp"
+ #include "oops/instanceKlass.hpp"
+ #include "oops/klassVtable.hpp"
++#include "oops/klass.inline.hpp"
+ #include "runtime/sharedRuntime.hpp"
+ #include "vmreg_arm.inline.hpp"
+ #ifdef COMPILER2


### PR DESCRIPTION
https://ci.adoptopenjdk.net/view/ev3dev/job/eljbuild/job/stretch-bleeding/11/console:
```
ERROR: Build failed for target 'bootcycle-images' in configuration 'linux-arm-client-release' (exit code 2) 
Stopping sjavac server

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-client_libjvm_gtest_objs_BUILD_GTEST_LIBJVM_link:
/build/jdk/build/linux-arm-client-release/hotspot/variant-client/libjvm/objs/vtableStubs_arm.o: In function `VtableStubs::create_vtable_stub(int)':
/build/jdk/src/hotspot/cpu/arm/vtableStubs_arm.cpp:91: undefined reference to `Klass::vtable_start_offset()'
collect2: error: ld returned 1 exit status
* For target hotspot_variant-client_libjvm_objs_BUILD_LIBJVM_link:
/build/jdk/build/linux-arm-client-release/hotspot/variant-client/libjvm/objs/vtableStubs_arm.o: In function `VtableStubs::create_vtable_stub(int)':
/build/jdk/src/hotspot/cpu/arm/vtableStubs_arm.cpp:91: undefined reference to `Klass::vtable_start_offset()'
collect2: error: ld returned 1 exit status

* All command lines available in /build/jdk/build/linux-arm-client-release/make-support/failure-logs.
=== End of repeated output ===
```