### PR TITLE
[config] Enable jdk.crypto.ec java module for JRI

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -16,7 +16,7 @@ CACERTFILE="$ABLDDIR/security/cacerts"
 JAVA_TMP="$BUILDDIR/jdk_tmp"
 TARBALL_MAX_DOWNLOADS=10
 
-JRI_MODULES="java.se,jdk.jdwp.agent,jdk.unsupported,jdk.management.agent,jdk.jartool"
+JRI_MODULES="java.se,jdk.jdwp.agent,jdk.unsupported,jdk.management.agent,jdk.jartool,jdk.crypto.ec"
 
 JTREG="$BUILDDIR/jtreg"
 JTREG_URL="https://ci.adoptopenjdk.net/view/Dependencies/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz"


### PR DESCRIPTION
Some sites expose such a TLS configuration that java is unable to proceed with TLS handshake without supporting elliptic curve cryptography. This adds the module to JRI to fix it for these websites.

Related to https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/728