### PR TITLE
[pkg] fix: remove explicit qemu-user-static use

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -4,27 +4,30 @@ FROM ev3dev/ev3dev-$DEBIAN_RELEASE-ev3-base
 ARG DEBIAN_RELEASE
 ENV DISTRO=$DEBIAN_RELEASE
 
-# copy QEMU
+# copy QEMU for x86 hosts (binfmt_misc is required)
 COPY qemu-arm-static /usr/bin/qemu-arm-static
 
 # install packaging utilities
-RUN ["/usr/bin/qemu-arm-static", "/bin/bash", "-c", \
-     "apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install --yes --no-install-recommends devscripts debhelper fakeroot zip unzip gnupg dctrl-tools dput liblcms2-2"]
+RUN apt-get -qq update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qq install --yes --no-install-recommends \
+        devscripts debhelper fakeroot \
+        zip unzip \
+        gnupg dctrl-tools dput \
+        liblcms2-2
 
 # prepare a nonroot user
 COPY compiler.sudoers /etc/sudoers.d/compiler
-RUN ["/usr/bin/qemu-arm-static", "/bin/bash", "-c", \
-    "chmod 0440 /etc/sudoers.d/compiler && adduser --disabled-password --gecos \"\" compiler && usermod -a -G sudo compiler"]
+RUN chmod 0440 /etc/sudoers.d/compiler && \
+    adduser --disabled-password --gecos \"\" compiler && usermod -a -G sudo compiler
 
 # copy build patches & scripts
 COPY *.awk *.patch *.sh /opt/jdkpkg/
 COPY debian/ /opt/jdkpkg/debian/
-RUN ["/usr/bin/qemu-arm-static", "/bin/bash", "-c", "chmod +x /opt/jdkpkg/*.sh"]
+RUN chmod +x /opt/jdkpkg/*.sh
 
 # this directory should be mounted
 VOLUME /build
 
 USER compiler
 WORKDIR /opt/jdkpkg
-ENTRYPOINT ["/usr/bin/qemu-arm-static", "/bin/bash", "-c"]
-CMD ["/opt/jdkpkg/package.sh"]
+CMD ["/bin/bash", "-c", "/opt/jdkpkg/package.sh"]


### PR DESCRIPTION
Explicit use of QEMU breaks ARM32/64 hosts as QEMU is installed as a x86-64 binary.
