### PR TITLE
[pkg] fix: drop dependency on ca-certificates-java

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -13,8 +13,7 @@ Package: @@package@@
 Architecture: armel
 Multi-Arch: same
 Pre-Depends: ${dpkg:Depends}
-Depends: ${cacert:Depends},
-  ${jcommon:Depends}, ${dlopenhl:Depends},
+Depends: ${jcommon:Depends}, ${dlopenhl:Depends},
   ${mountpoint:Depends},
   ${shlibs:Depends}, ${misc:Depends}
 Recommends: ${dlopenhl:Recommends}

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -18,7 +18,6 @@ dlopen_hl_recommends =
 
 control_vars  = '-Vdlopenhl:Depends=$(dlopen_hl_depends)'
 control_vars += '-Vdlopenhl:Recommends=$(dlopen_hl_recommends)'
-control_vars += '-Vcacert:Depends=ca-certificates-java'
 control_vars += '-Vmountpoint:Depends=util-linux (>= 2.26.2-4)'
 control_vars += '-Vjcommon:Depends=java-common (>= 0.28)'
 control_vars += '-Vdefaultvm:Provides='
@@ -51,9 +50,6 @@ copy_java: binary-pre mkdirs
 	cp -rf bin conf legal lib release metadata debian/$(pkgname)/usr/lib/jvm/$(pkgname)/
 
 mkcustom: binary-pre mkdirs copy_java templates
-	# ca certificates
-	rm debian/$(pkgname)/usr/lib/jvm/$(pkgname)/lib/security/cacerts
-	ln -s /etc/ssl/certs/java/cacerts debian/$(pkgname)/usr/lib/jvm/$(pkgname)/lib/security/cacerts
 	# custom config
 	install -o root -g root -m 0644 debian/nss.cfg debian/$(pkgname)/etc/$(pkgname)/security/nss.cfg
 	install -o root -g root -m 0644 debian/jvm.cfg debian/$(pkgname)/etc/$(pkgname)/jvm.cfg
@@ -72,7 +68,6 @@ mkcustom: binary-pre mkdirs copy_java templates
 	        conf/logging.properties \
 	        conf/net.properties \
 	        conf/sound.properties \
-	        lib/security/cacerts \
 	        lib/security/blacklisted.certs \
 	        lib/security/default.policy \
 	        lib/security/public_suffix_list.dat \


### PR DESCRIPTION
Related to https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/728#issuecomment-633680662

The problem is that the `ca-certificates-java` package relies on `jri-N-ev3` for the `java` command; however `jri-N-ev3` also depends on `ca-certificates java`.

The proper fix would be to specify a self-dependency as outlined in https://github.com/AdoptOpenJDK/openjdk-installer/issues/105#issuecomment-493939825. This will probably somehow break the dependency cycle so that `jri-N-ev3` is installed first and only then the `ca-certificates-java` package gets installed.

This is nice, but the installation failure damages the system `cacerts` file and simple `apt install --reinstall` is *not* enough to fix this, instead AFAIK all java packages have to be uninstalled and then reinstalled again.

Let's instead ship the cacerts that ship with other AdoptOpenJDK builds. This will fix cacerts error from the start. If the user wants to use `ca-certificates-java`, this actually makes it possible to do so -
they just need to install the package after `jri-N-ev3` and then symlink `/usr/lib/jvm/jri-N-ev3/lib/security/cacerts` to `/etc/ssl/certs/java/cacerts` which is managed by `ca-certificates-java`.

Nothing is perfect, though. The potential issue with Adopt's CA certificates is that they seem pretty old (~ 3 years). It seems that this is going to change: https://github.com/AdoptOpenJDK/openjdk-support/issues/13 That change will however impact the JDK build script and not the packaging script.