### PR TITLE
[scripts] feat: use CA certificates from Mozilla

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -6,12 +6,8 @@ SCRIPTDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILDDIR="/build"
 # jdk repository directory
 JDKDIR="$BUILDDIR/jdk"
-# openjdk-build repo dir
-ABLDDIR="$BUILDDIR/openjdk-build"
-# openjdk-build repo
-ABLDREPO="https://github.com/AdoptOpenJDK/openjdk-build.git"
-# cacertfile
-CACERTFILE="$ABLDDIR/security/cacerts"
+# CA certificate database
+CACERTFILE="$BUILDDIR/cacerts"
 # hg tarball
 JAVA_TMP="$BUILDDIR/jdk_tmp"
 TARBALL_MAX_DOWNLOADS=10

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -157,12 +157,3 @@ if [ ! -d "$JDKDIR" ]; then
 else
   echo "[FETCH] Directory for JDK repository exists, assuming everything has been done already." 2>&1
 fi
-
-
-if [ -d "$ABLDDIR" ]; then
-  rm -rf "$ABLDDIR"
-fi
-
-# clone the root project
-echo "[FETCH] Cloning openjdk-build repo"
-git clone --depth 1 "$ABLDREPO" "$ABLDDIR"

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -33,3 +33,12 @@ if [ ! -d "$JTREG" ]; then
 else
   echo "[PREPARE] Using cached jtreg directory"
 fi
+
+if [ ! -f "$CACERTFILE" ]; then
+  echo "[PREPARE] Generating CA certificate database"
+  cd "$BUILDDIR"
+  wget -nv -N https://github.com/use-sparingly/keyutil/releases/download/0.4.0/keyutil-0.4.0.jar
+  wget -nv -N https://raw.githubusercontent.com/curl/curl/master/lib/mk-ca-bundle.pl
+  perl mk-ca-bundle.pl ca-bundle.crt
+  "$HOSTJDK/bin/java" -jar keyutil-0.4.0.jar --import --new-keystore "$CACERTFILE" --password changeit --force-new-overwrite --import-pem-file ca-bundle.crt
+fi


### PR DESCRIPTION
Related to https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/728#issuecomment-633693427
Inspired by https://github.com/AdoptOpenJDK/openjdk-support/issues/13#issuecomment-626147267

This removes the use of the CA certificates bundled in the AdoptOpenJDK repository. Instead the CA certificates are generated before each build from the Mozilla's trust database.

This should ensure the most browser-like experience which I'd expect users to expect.