### PR TITLE
[pkg] fix: add jri-N-ev3 self-dep to fix ca-certificates-java

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -13,7 +13,8 @@ Package: @@package@@
 Architecture: armel
 Multi-Arch: same
 Pre-Depends: ${dpkg:Depends}
-Depends: ${cacert:Depends},
+Depends: @@package@@ (= ${binary:Version}),
+  ${cacert:Depends},
   ${jcommon:Depends}, ${dlopenhl:Depends},
   ${mountpoint:Depends},
   ${shlibs:Depends}, ${misc:Depends}


### PR DESCRIPTION
With this PR, new clean JRI installations should have working system-wide java ca certificates. This is a non-invasive alternative to https://github.com/ev3dev-lang-java/openjdk-ev3/pull/61 ~+ https://github.com/ev3dev-lang-java/openjdk-ev3/pull/62~ _(orthogonal PR)_.

The problem is that ca-certificates-java depend on jri-N-ev3 when it is not yet ready; see https://github.com/ev3dev-lang-java/openjdk-ev3/pull/61#issuecomment-633708427 for the console output.

The fix is likely based on a trick for making dpkg configure this package first before configuring other packages that depend on it.

The downside of this solution is that pre-existing installations will not get fixed. They will still potentially have corrupted trust store from previous failed installations. I don't know what the state of ev3dev is, but if the package installation fails even in the ev3dev base image, then *all* EV3 installations have the trust store corrupted.

The trust store can be un-corrupted by completely removing and reinstalling ca-certificates-java. This is quite a heavy operation for EV3, so this is a reason why the other solution might be preferred.

EDIT: see comments in https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/731 for further analysis