### PR TITLE
[scripts] feat: use CA certificates from OpenJDK

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,7 +27,6 @@ fi
 #   - Force softfloat runtime:  -D__SOFTFP__
 # Fix the "internal" string:   --with-version-string="<version>"
 # Use correct JNI path:        --with-jni-libpath=<dir1>:<dir2>...
-# Use AdoptOpenJDK CA certs:   --with-cacerts-file=<path>
 # Use correct debug level      --with-debug-level=<level>
 # Help to find freetype:       --with-freetype-lib=/usr/lib/arm-linux-gnueabi
 #                              --with-freetype-include=/usr/include
@@ -58,7 +57,6 @@ if [ "$JDKPLATFORM" == "ev3" ]; then
                    --with-version-string="$JAVA_VERSION" \
                    $JNI_PATH_FLAGS \
                    $VENDOR_FLAGS \
-                   --with-cacerts-file="$CACERTFILE" \
                    --with-debug-level=$HOTSPOT_DEBUG \
                    --with-native-debug-symbols=internal \
                    --with-stdc++lib=dynamic \

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -6,12 +6,6 @@ SCRIPTDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILDDIR="/build"
 # jdk repository directory
 JDKDIR="$BUILDDIR/jdk"
-# openjdk-build repo dir
-ABLDDIR="$BUILDDIR/openjdk-build"
-# openjdk-build repo
-ABLDREPO="https://github.com/AdoptOpenJDK/openjdk-build.git"
-# cacertfile
-CACERTFILE="$ABLDDIR/security/cacerts"
 # hg tarball
 JAVA_TMP="$BUILDDIR/jdk_tmp"
 TARBALL_MAX_DOWNLOADS=10

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -157,12 +157,3 @@ if [ ! -d "$JDKDIR" ]; then
 else
   echo "[FETCH] Directory for JDK repository exists, assuming everything has been done already." 2>&1
 fi
-
-
-if [ -d "$ABLDDIR" ]; then
-  rm -rf "$ABLDDIR"
-fi
-
-# clone the root project
-echo "[FETCH] Cloning openjdk-build repo"
-git clone --depth 1 "$ABLDREPO" "$ABLDDIR"


### PR DESCRIPTION
This removes the use of obsolete AdoptOpenJDK-specific CA certificates, now upstream OpenJDK CA certificates are used instead.

This is an alternative to https://github.com/ev3dev-lang-java/openjdk-ev3/pull/62 as outlined in https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/731#issuecomment-634734637