### PR TITLE
[docker] fix: remove superfluous VOLUME instruction

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -26,9 +26,6 @@ COPY *.awk *.patch *.sh /opt/jdkpkg/
 COPY debian/ /opt/jdkpkg/debian/
 RUN chmod +x /opt/jdkpkg/*.sh
 
-# this directory should be mounted
-VOLUME /build
-
 USER compiler
 WORKDIR /opt/jdkpkg
 CMD ["/bin/bash", "-c", "/opt/jdkpkg/package.sh"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -21,9 +21,6 @@ ENV BUILDER_EXTRA=${extra}
 COPY *.awk *.patch *.sh /opt/jdkcross/
 RUN chmod +x /opt/jdkcross/*.sh
 
-# this directory should be mounted
-VOLUME /build
-
 USER compiler
 WORKDIR /opt/jdkcross
 CMD ["/opt/jdkcross/autorun.sh"]


### PR DESCRIPTION
this creates a separate volume, which is not what we want
we want it to be mountable, which it always is