### PR TITLE
[scripts] feat: use CA certificates from Mozilla

### DIFF
--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -166,3 +166,9 @@ fi
 # clone the root project
 echo "[FETCH] Cloning openjdk-build repo"
 git clone --depth 1 "$ABLDREPO" "$ABLDDIR"
+
+if [ ! -f "$CACERTFILE" ]; then
+  echo "[FETCH] Generating CA certificate database"
+  cd "$(dirname "$CACERTFILE")"
+  ./mk-cacerts.sh --keytool "$HOSTJDK/bin/keytool"
+fi


### PR DESCRIPTION
This enables the generation of CAcerts database from Mozilla's list of trustworthy certificates as implemented in AdoptOpenJDK's build repository.

Related to https://github.com/ev3dev-lang-java/ev3dev-lang-java/issues/728#issuecomment-633693427
Related to https://github.com/AdoptOpenJDK/openjdk-build/commit/9cb3ddcb8f3550aa904f086146be0cdd242d7e8a

This is a reduced form of https://github.com/ev3dev-lang-java/openjdk-ev3/pull/62 that uses AdoptOpenJDK's code to do this instead of using our own script for this.